### PR TITLE
use the --renderToDisk argument on hugo server locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "lint": "eslint src",
     "start": "run-p start:**",
-    "start:hugo": "hugo server -s site -p 3000 --bind 0.0.0.0",
+    "start:hugo": "hugo server -s site -p 3000 --bind 0.0.0.0 --renderToDisk",
     "start:webpack": "webpack-dev-server --config src/webpack/webpack.dev.js --hot --host 0.0.0.0",
     "prebuild": "rimraf dist",
     "build": "npm run build:webpack && npm run build:hugo && npm run build:githash",


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/ocw-course-hugo-theme/pull/3

#### What's this PR do?
This PR adds the `--renderToDisk` argument to the local hugo server command so content can be injected at runtime.

#### How should this be manually tested?
Install dependencies and run the site with:

```
yarn install
npm start
```

Verify that you see the site rendering to disk at `site/public`.  Create a test file like `test.html` or something similar in `site/public`, then verify you can see it's contents at http://localhost:3000/test.html

#### Any background context you want to provide?
This is necessary for testing the production build method of building courses externally and dropping them into the running site.
