### PR TITLE
Add OCW News to front page

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -8,3 +8,8 @@ relativeURLs = false
 # See configuration options for more details:
 # https://gohugo.io/getting-started/configuration/#toml-configuration
 disableKinds = ["RSS", "taxonomy", "taxonomyTerm"]
+
+[caches]
+[caches.getjson]
+# set getJSON cache age small enough to refresh on every build but large enough to cache usefully within a build
+maxAge = "5m"

--- a/site/layouts/home.html
+++ b/site/layouts/home.html
@@ -59,7 +59,6 @@
   {{ $coursePages := where $pages "Type" "==" "course" }}
   {{ $childPages := where $coursePages ".Params.layout" "==" "course_home" }}
   {{ partial "home_course_cards.html" $childPages }}
-  {{ partial "ocw_news.html" . }}
   <div class="beta-dialog bg-dark-gray px-8 py-4 d-none">
     <h2>Next Generation OpenCourseWare</h2>
     <p>
@@ -100,6 +99,7 @@
       </div>
     </div>
   </div>
+  {{ partial "ocw_news.html" . }}
   {{ partial "home_testimonials.html" . }}
   <div class="social-cards-wrapper">
     <div class="social-cards d-flex justify-content-center container w-100">

--- a/site/layouts/home.html
+++ b/site/layouts/home.html
@@ -59,6 +59,7 @@
   {{ $coursePages := where $pages "Type" "==" "course" }}
   {{ $childPages := where $coursePages ".Params.layout" "==" "course_home" }}
   {{ partial "home_course_cards.html" $childPages }}
+  {{ partial "ocw_news.html" . }}
   <div class="beta-dialog bg-dark-gray px-8 py-4 d-none">
     <h2>Next Generation OpenCourseWare</h2>
     <p>

--- a/site/layouts/partials/ocw_news.html
+++ b/site/layouts/partials/ocw_news.html
@@ -1,0 +1,21 @@
+<div class="ocw-news mx-auto container">
+    <h3><span class="ocw">OCW</span> News</h3>
+    <div class="d-grid items-row">
+        {{- $newsItems := getJSON (print (strings.TrimSuffix "/" (getenv "OCW_STUDIO_BASE_URL")) "/api/news/") -}}
+        {{ if $newsItems }}
+            {{- range $index, $item := (first 4 $newsItems.items) -}}
+            <div class="item item-{{ $index }}"
+                 style="background: linear-gradient(to bottom, transparent, #777777), url({{ $item.image }})">
+                <a href="{{ $item.link.text }}" class="py-2 px-3 text-white text-decoration-none">
+                    {{ $item.title.text }}
+                </a>
+            </div>
+            {{ end }}
+        {{ end }}
+    </div>
+    <div class="d-flex py-4">
+        <div class="ml-auto">
+            <a class="view-all-news-link" href="https://www.ocw-openmatters.org/">View All News Stories</a>
+        </div>
+    </div>
+</div>

--- a/src/css/home.scss
+++ b/src/css/home.scss
@@ -484,6 +484,7 @@ $maxwidth: 1280px;
     font-family: Helvetica, sans-serif;
     font-weight: 300;
     font-size: 28px;
+    margin-bottom: 20px;
 
     .ocw {
       color: $orange;

--- a/src/css/home.scss
+++ b/src/css/home.scss
@@ -476,3 +476,77 @@ $maxwidth: 1280px;
     }
   }
 }
+
+.ocw-news {
+  max-width: $maxwidth;
+
+  h3 {
+    font-family: Helvetica, sans-serif;
+    font-weight: 300;
+    font-size: 28px;
+
+    .ocw {
+      color: $orange;
+      font-weight: 600;
+    }
+  }
+
+  .items-row {
+    height: 375px;
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr 1fr;
+    grid-template-rows: 1fr 1fr;
+    grid-gap: 20px;
+
+    @include media-breakpoint-down(md) {
+      grid-template-columns: 1fr;
+      grid-template-rows: 1fr;
+    }
+
+    .item {
+      width: 100%;
+      background-size: cover !important;
+      display: flex;
+      align-items: end;
+
+      a {
+        font-size: 20px;
+        line-height: 24px;
+        font-weight: bold;
+      }
+
+      &.item-0 {
+        grid-row: 1 / 3;
+        grid-column: 1 / 3;
+      }
+
+      &.item-1 {
+        grid-row: 1;
+        grid-column: 3;
+      }
+
+      &.item-2 {
+        grid-row: 1;
+        grid-column: 4;
+      }
+
+      &.item-3 {
+        grid-row: 2;
+        grid-column: 3 / 5;
+      }
+
+      &.item-1,
+      &.item-2,
+      &.item-3 {
+        @include media-breakpoint-down(md) {
+          display: none;
+        }
+      }
+    }
+  }
+
+  .view-all-news-link {
+    color: $blue;
+    font-size: 16px;
+  }
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #6 

#### What's this PR do?
Implements a design for a OCW News feed on the home page

#### How should this be manually tested?
 - Start OCW studio. It's providing a JSON feed of OCW News so it's a requirement to test this PR.
 - Run `OCW_STUDIO_BASE_URL=http://localhost:8043 npm start` and view the front page. You should see something that looks similar to the screenshots.

#### Screenshots (if appropriate)
*Note that the course carousel is empty because I don't have any courses set up for ocw-www on my local instance

Desktop:
![Screenshot_2021-01-14 Screenshot](https://user-images.githubusercontent.com/863262/104640859-0894d280-5677-11eb-8fc5-bbac0fa34676.png)



Tablet:
![Screenshot_2021-01-14 Screenshot(1)](https://user-images.githubusercontent.com/863262/104640784-eef38b00-5676-11eb-9734-f66bc8ae64e0.png)


Mobile:
![Screenshot_2021-01-14 Screenshot(2)](https://user-images.githubusercontent.com/863262/104640802-f3b83f00-5676-11eb-9c5c-c8a85c6c2ffa.png)


