### PR TITLE
New courses carousel, populated from API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Webpack build
         run: npm run build
+        env:
+          OCW_STUDIO_BASE_URL: "https://example.com"
 
       - name: Code formatting
         run: npm run fmt:check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,13 @@ jobs:
         run: npm run test
 
       - name: Webpack build
-        run: npm run build
-        env:
-          OCW_STUDIO_BASE_URL: "https://example.com"
+        run: |
+          export TMP=$(mktemp)
+          echo 'ignoreErrors = ["error-remote-getjson"]' > $TMP
+          cat site/config.toml >> $TMP
+          rm site/config.toml
+          mv $TMP site/config.toml
+          npm run build
 
       - name: Code formatting
         run: npm run fmt:check

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,13 @@ jobs:
         run: yarn install --frozen-lockfile --ignore-engines --prefer-offline
 
       - name: build site
-        run: npm run build
+        run: |
+          export TMP=$(mktemp)
+          echo 'ignoreErrors = ["error-remote-getjson"]' > $TMP
+          cat site/config.toml >> $TMP
+          rm site/config.toml
+          mv $TMP site/config.toml
+          npm run build
 
       - name: Deploy PR Preview to Netlify
         uses: nwtgck/actions-netlify@v1.1
@@ -89,7 +95,7 @@ jobs:
           body=$(echo '${{ steps.lighthouseCheck.outputs.lighthouseCheckResults }}' | node util/formatLighthouseComment.js)
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
-          body="${body//$'\r'/'%0D'}" 
+          body="${body//$'\r'/'%0D'}"
           echo ::set-output name=body::$body
 
       - name: Find Comment

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "fuse.js": "^6.4.1",
     "gulp": "^4.0.2",
     "hammerjs": "2.0.7",
-    "hugo-bin": "*",
+    "hugo-bin": "^0.68.0",
     "imagesloaded": "4.1.1",
     "imports-loader": "^0.8.0",
     "isomorphic-fetch": "^2.2.1",

--- a/site/layouts/partials/home_course_cards.html
+++ b/site/layouts/partials/home_course_cards.html
@@ -1,68 +1,70 @@
-<div class="new-courses">
-    <div class="course-cards container mt-3 mx-auto w-100">
-        {{- $courseItems := getJSON (print (strings.TrimSuffix "/" (getenv "OCW_STUDIO_BASE_URL")) "/api/websites/courses/new/") -}}
-         {{ $breakdowns := (dict "xs-sm" (dict "size" 1 "class" "d-flex d-md-none") "md" (dict "size" 2 "class" "d-none d-md-flex d-lg-none") "lg" (dict "size" 3 "class" "d-none d-lg-flex d-xl-none") "xl" (dict "size" 4 "class" "d-none d-xl-flex")) }}
-        <!-- list adapted from https://getbootstrap.com/docs/4.0/utilities/display/#hiding-elements -->
-        {{ range $breakpoint, $carouselInfo := $breakdowns }}
-            {{ $itemsInCarousel := index $carouselInfo "size" }}
-            {{ $breakpointVisibilityClass := index $carouselInfo "class" }}
-            {{ $isMobile := (eq $itemsInCarousel 1) }}
-            <div class="{{ $breakpointVisibilityClass }}">
-                <div id="carousel-{{ $breakpoint }}" class="carousel slide">
-                    <div class="carousel-header d-flex flex-row justify-content-between font-weight-bold text-uppercase">
-                        <h3 class="new-courses-title">New Courses</h3>
-                        <h4 class="d-flex">
-                            <a href="#carousel-{{ $breakpoint }}" role="button" data-slide="prev" class="bg-white prev">
-                                <span class="material-icons">keyboard_arrow_left</span>
-                                Previous
-                            </a>
-                            <a href="#carousel-{{ $breakpoint }}" role="button" data-slide="next" class="bg-white next">
-                                Next
-                                <span class="material-icons">keyboard_arrow_right</span>
-                            </a>
-                        </h4>
-                    </div>
-                    <div class="carousel-inner d-flex {{ if not $isMobile }}container{{ end }} mt-2 px-0">
-                        {{- range $index, $page := (first 10 $courseItems.results) -}}
-                            {{ with $page }}
-                                {{ $courseId := $page.metadata.course_id }}
-                                {{ $courseData := $page.metadata}}
-                                {{ $modulo := (mod $index $itemsInCarousel) }}
-                                {{ $group := (div $index $itemsInCarousel) }}
-                                {{ if eq $modulo 0 }}
-                                    <div class="carousel-item {{ if not $isMobile }}row{{end}} {{ if eq $group 0 }}active{{ end }}">
-                                {{ end }}
-                                        <div class="course-card-wrapper {{ if not $isMobile }}col-{{ (div 12 $itemsInCarousel) }}{{ end }} w-100 d-flex justify-content-center">
-                                            <div class="course-card card bg-white">
-                                                <a href="{{  $page.url_path }}">
-                                                  <img src="{{ $courseData.course_image_url }}" alt="Thumbnail for {{ $courseData.course_title }}"/>
-                                                </a>
-                                                <div class="course-card-content pt-1 px-3 pb-3">
-                                                    <div class="course-level">
-                                                        {{ index $courseData.course_numbers 0 }} | {{ $courseData.level }}
-                                                    </div>
-                                                    <div class="pt-1">
-                                                        <h5>
-                                                            <a href="/courses/{{ $page.url_path }}">{{ $courseData.course_title }}</a>
-                                                        </h5>
-                                                    </div>
-                                                    <div class="pt-1">
-                                                        <span class="card-label">Instructors(s):</span> {{ delimit (first 3 (uniq $courseData.instructors)) ", " }}
-                                                    </div>
-                                                    <div class="pt-2">
-                                                        <span class="card-label">Topic(s):</span> {{ partial "topics_summary.html" $courseData.topics }}
+{{- $courseItems := getJSON (print (strings.TrimSuffix "/" (getenv "OCW_STUDIO_BASE_URL")) "/api/websites/?type=course") -}}
+{{ if $courseItems.results }}
+    <div class="new-courses">
+        <div class="course-cards container mt-3 mx-auto w-100">
+             {{ $breakdowns := (dict "xs-sm" (dict "size" 1 "class" "d-flex d-md-none") "md" (dict "size" 2 "class" "d-none d-md-flex d-lg-none") "lg" (dict "size" 3 "class" "d-none d-lg-flex d-xl-none") "xl" (dict "size" 4 "class" "d-none d-xl-flex")) }}
+            <!-- list adapted from https://getbootstrap.com/docs/4.0/utilities/display/#hiding-elements -->
+            {{ range $breakpoint, $carouselInfo := $breakdowns }}
+                {{ $itemsInCarousel := index $carouselInfo "size" }}
+                {{ $breakpointVisibilityClass := index $carouselInfo "class" }}
+                {{ $isMobile := (eq $itemsInCarousel 1) }}
+                <div class="{{ $breakpointVisibilityClass }}">
+                    <div id="carousel-{{ $breakpoint }}" class="carousel slide">
+                        <div class="carousel-header d-flex flex-row justify-content-between font-weight-bold text-uppercase">
+                            <h3 class="new-courses-title">New Courses</h3>
+                            <h4 class="d-flex">
+                                <a href="#carousel-{{ $breakpoint }}" role="button" data-slide="prev" class="bg-white prev">
+                                    <span class="material-icons">keyboard_arrow_left</span>
+                                    Previous
+                                </a>
+                                <a href="#carousel-{{ $breakpoint }}" role="button" data-slide="next" class="bg-white next">
+                                    Next
+                                    <span class="material-icons">keyboard_arrow_right</span>
+                                </a>
+                            </h4>
+                        </div>
+                        <div class="carousel-inner d-flex {{ if not $isMobile }}container{{ end }} mt-2 px-0">
+                            {{- range $index, $courseItem := (first 10 $courseItems.results) -}}
+                                {{ with $courseItem }}
+                                    {{ $courseId := $courseItem.metadata.course_id }}
+                                    {{ $courseData := $courseItem.metadata}}
+                                    {{ $modulo := (mod $index $itemsInCarousel) }}
+                                    {{ $group := (div $index $itemsInCarousel) }}
+                                    {{ if eq $modulo 0 }}
+                                        <div class="carousel-item {{ if not $isMobile }}row{{end}} {{ if eq $group 0 }}active{{ end }}">
+                                    {{ end }}
+                                            <div class="course-card-wrapper {{ if not $isMobile }}col-{{ (div 12 $itemsInCarousel) }}{{ end }} w-100 d-flex justify-content-center">
+                                                <div class="course-card card bg-white">
+                                                    <a href="{{  $courseItem.url_path }}">
+                                                      <img src="{{ $courseData.course_image_url }}" alt="Thumbnail for {{ $courseData.course_title }}"/>
+                                                    </a>
+                                                    <div class="course-card-content pt-1 px-3 pb-3">
+                                                        <div class="course-level">
+                                                            {{ index $courseData.course_numbers 0 }} | {{ $courseData.level }}
+                                                        </div>
+                                                        <div class="pt-1">
+                                                            <h5>
+                                                                <a href="/courses/{{ $courseItem.url_path }}">{{ $courseData.course_title }}</a>
+                                                            </h5>
+                                                        </div>
+                                                        <div class="pt-1">
+                                                            <span class="card-label">Instructors(s):</span> {{ delimit (first 3 (uniq $courseData.instructors)) ", " }}
+                                                        </div>
+                                                        <div class="pt-2">
+                                                            <span class="card-label">Topic(s):</span> {{ partial "topics_summary.html" $courseData.topics }}
+                                                        </div>
                                                     </div>
                                                 </div>
                                             </div>
+                                    {{ if (or (eq $modulo (sub $itemsInCarousel 1)) (eq $index (sub 10 1))) }}
                                         </div>
-                                {{ if (or (eq $modulo (sub $itemsInCarousel 1)) (eq $index (sub 10 1))) }}
-                                    </div>
+                                    {{ end }}
                                 {{ end }}
                             {{ end }}
-                        {{ end }}
+                        </div>
                     </div>
                 </div>
-            </div>
-        {{ end }}
+            {{ end }}
+        </div>
     </div>
-</div>
+{{ end }}

--- a/site/layouts/partials/home_course_cards.html
+++ b/site/layouts/partials/home_course_cards.html
@@ -1,7 +1,7 @@
 <div class="new-courses">
     <div class="course-cards container mt-3 mx-auto w-100">
-        {{ $pages := . }}
-        {{ $breakdowns := (dict "xs-sm" (dict "size" 1 "class" "d-flex d-md-none") "md" (dict "size" 2 "class" "d-none d-md-flex d-lg-none") "lg" (dict "size" 3 "class" "d-none d-lg-flex d-xl-none") "xl" (dict "size" 4 "class" "d-none d-xl-flex")) }}
+        {{- $courseItems := getJSON (print (strings.TrimSuffix "/" (getenv "OCW_STUDIO_BASE_URL")) "/api/websites/courses/new/") -}}
+         {{ $breakdowns := (dict "xs-sm" (dict "size" 1 "class" "d-flex d-md-none") "md" (dict "size" 2 "class" "d-none d-md-flex d-lg-none") "lg" (dict "size" 3 "class" "d-none d-lg-flex d-xl-none") "xl" (dict "size" 4 "class" "d-none d-xl-flex")) }}
         <!-- list adapted from https://getbootstrap.com/docs/4.0/utilities/display/#hiding-elements -->
         {{ range $breakpoint, $carouselInfo := $breakdowns }}
             {{ $itemsInCarousel := index $carouselInfo "size" }}
@@ -23,11 +23,10 @@
                         </h4>
                     </div>
                     <div class="carousel-inner d-flex {{ if not $isMobile }}container{{ end }} mt-2 px-0">
-                        {{ $pagesChunk := (first 10 $pages) }}
-                        {{ range $index, $page := $pagesChunk }}
+                        {{- range $index, $page := (first 10 $courseItems.results) -}}
                             {{ with $page }}
-                                {{ $courseId := $page.Params.course_id }}
-                                {{ $courseData := index .Site.Data.courses $courseId }}
+                                {{ $courseId := $page.metadata.course_id }}
+                                {{ $courseData := $page.metadata}}
                                 {{ $modulo := (mod $index $itemsInCarousel) }}
                                 {{ $group := (div $index $itemsInCarousel) }}
                                 {{ if eq $modulo 0 }}
@@ -35,7 +34,7 @@
                                 {{ end }}
                                         <div class="course-card-wrapper {{ if not $isMobile }}col-{{ (div 12 $itemsInCarousel) }}{{ end }} w-100 d-flex justify-content-center">
                                             <div class="course-card card bg-white">
-                                                <a href="{{ .Permalink }}">
+                                                <a href="{{  $page.url_path }}">
                                                   <img src="{{ $courseData.course_image_url }}" alt="Thumbnail for {{ $courseData.course_title }}"/>
                                                 </a>
                                                 <div class="course-card-content pt-1 px-3 pb-3">
@@ -44,7 +43,7 @@
                                                     </div>
                                                     <div class="pt-1">
                                                         <h5>
-                                                            <a href="{{ .Permalink }}">{{ $courseData.course_title }}</a>
+                                                            <a href="/courses/{{ $page.url_path }}">{{ $courseData.course_title }}</a>
                                                         </h5>
                                                     </div>
                                                     <div class="pt-1">
@@ -56,7 +55,7 @@
                                                 </div>
                                             </div>
                                         </div>
-                                {{ if (or (eq $modulo (sub $itemsInCarousel 1)) (eq $index (sub (len $pagesChunk) 1))) }}
+                                {{ if (or (eq $modulo (sub $itemsInCarousel 1)) (eq $index (sub 10 1))) }}
                                     </div>
                                 {{ end }}
                             {{ end }}

--- a/site/layouts/partials/topics_summary.html
+++ b/site/layouts/partials/topics_summary.html
@@ -1,0 +1,11 @@
+{{- $topicsList := slice -}}
+{{- range $topic := . -}}
+    {{- if not $topic.subtopics -}}
+        {{- $topicsList = $topicsList | append (title $topic.topic) -}}
+    {{- else -}}
+        {{- range $subtopic := $topic.subtopics -}}
+        {{- $topicsList = $topicsList | append (title $subtopic.subtopic) -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+{{- delimit (first 3 (uniq $topicsList)) ", " -}}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6560,10 +6560,10 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
-hugo-bin@*:
-  version "0.58.0"
-  resolved "https://registry.yarnpkg.com/hugo-bin/-/hugo-bin-0.58.0.tgz#f8ec63199c1e73135d3e24eb41297201f9172d43"
-  integrity sha512-lTn+UrsTFJLlTaFWVgY1LcwObc+XeZ5O49Bh2I0megfEBloqR4CuYKjg237IIKZPvh+PIi4ZDv+UrPCBbeKBCA==
+hugo-bin@^0.68.0:
+  version "0.68.0"
+  resolved "https://registry.yarnpkg.com/hugo-bin/-/hugo-bin-0.68.0.tgz#504909c66fbe16f98683b8625f868c2b7d372dfc"
+  integrity sha512-QdmnjN45BGCp4mlKMFUIZFzuZJ/ClW0dVUbeUkgRgxfRlf444Sg5aPKXtLkQgpbP/jCVlxoyVt5sRmhntwtI8Q==
   dependencies:
     bin-wrapper "^4.1.0"
     pkg-conf "^3.1.0"


### PR DESCRIPTION
Based off #14 (thanks George!)

Depends on an API response from https://github.com/mitodl/ocw-studio/pull/19

#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #4 

#### What's this PR do?
Populates the new courses carousel from the ocw-studio API

#### How should this be manually tested?
You'll need ocw-studio (https://github.com/mitodl/ocw-studio/pull/19 branch) up and running, and at least a few OCW courses imported via `manage.py backpopulate_ocw_courses` (you can interrupt it after a few minutes, otherwise it will take about 45 minutes to complete).

For ocw-www:
```
export OCW_STUDIO_BASE_URL=http://localhost:8043
npm start
```

Go to the home page and you should a 'New Courses' carousel with up to 10 courses.  

To test that this section won't show up at all if there are no courses returned, you can temporarily change the api url in `home_course_cards.html` to `/api/websites/?type=notacourse`


#### Screenshots (if appropriate)
<img width="1310" alt="Screen Shot 2021-01-14 at 4 23 57 PM" src="https://user-images.githubusercontent.com/187676/104651618-e3f42700-5685-11eb-84e6-dadb2e42569b.png">
