### PR TITLE
prepend /courses/ onto thumbnail links

### DIFF
--- a/site/layouts/partials/home_course_cards.html
+++ b/site/layouts/partials/home_course_cards.html
@@ -35,7 +35,7 @@
                                     {{ end }}
                                             <div class="course-card-wrapper {{ if not $isMobile }}col-{{ (div 12 $itemsInCarousel) }}{{ end }} w-100 d-flex justify-content-center">
                                                 <div class="course-card card bg-white">
-                                                    <a href="{{  $courseItem.url_path }}">
+                                                    <a href="/courses/{{ $courseItem.url_path }}">
                                                       <img src="{{ $courseData.course_image_url }}" alt="Thumbnail for {{ $courseData.course_title }}"/>
                                                     </a>
                                                     <div class="course-card-content pt-1 px-3 pb-3">


### PR DESCRIPTION
#### Pre-Flight checklist
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?
Makes thumbnail links for new courses the same as title links

#### How should this be manually tested?
Run ocw-studio locally, set OCW_STUDIO_BASE_URL=http://localhost:8043
Click on the title and thumbnail for each course, you should end up at the same URL.  If you try the url path on ocw-beta.odl.mit.edu it should work.
