### PR TITLE
Implemented OCW news carousel in mobile/tablet widths

### DIFF
--- a/site/layouts/home.html
+++ b/site/layouts/home.html
@@ -60,6 +60,7 @@
   {{ $coursePages := where $pages "Type" "==" "course" }}
   {{ $childPages := where $coursePages ".Params.layout" "==" "course_home" }}
   {{ partial "home_course_cards.html" $childPages }}
+  {{ partial "ocw_news.html" . }}
   <div class="beta-dialog bg-dark-gray px-8 py-4 d-none">
     <h2>Next Generation OpenCourseWare</h2>
     <p>

--- a/site/layouts/home.html
+++ b/site/layouts/home.html
@@ -60,7 +60,6 @@
   {{ $coursePages := where $pages "Type" "==" "course" }}
   {{ $childPages := where $coursePages ".Params.layout" "==" "course_home" }}
   {{ partial "home_course_cards.html" $childPages }}
-  {{ partial "ocw_news.html" . }}
   <div class="beta-dialog bg-dark-gray px-8 py-4 d-none">
     <h2>Next Generation OpenCourseWare</h2>
     <p>

--- a/site/layouts/partials/carousel_controls.html
+++ b/site/layouts/partials/carousel_controls.html
@@ -1,0 +1,10 @@
+<div class="carousel-controls d-flex">
+    <a href="#{{ . }}" role="button" data-slide="prev" class="bg-white prev">
+        <span class="material-icons">keyboard_arrow_left</span>
+        Previous
+    </a>
+    <a href="#{{ . }}" role="button" data-slide="next" class="bg-white next">
+        Next
+        <span class="material-icons">keyboard_arrow_right</span>
+    </a>
+</div>

--- a/site/layouts/partials/home_course_cards.html
+++ b/site/layouts/partials/home_course_cards.html
@@ -1,27 +1,18 @@
 {{- $courseItems := getJSON (print (strings.TrimSuffix "/" (getenv "OCW_STUDIO_BASE_URL")) "/api/websites/?type=course") -}}
 {{ if $courseItems.results }}
-    <div class="new-courses">
-        <div class="course-cards container mt-3 mx-auto w-100">
-             {{ $breakdowns := (dict "xs-sm" (dict "size" 1 "class" "d-flex d-md-none") "md" (dict "size" 2 "class" "d-none d-md-flex d-lg-none") "lg" (dict "size" 3 "class" "d-none d-lg-flex d-xl-none") "xl" (dict "size" 4 "class" "d-none d-xl-flex")) }}
+        <div class="new-courses course-cards container mt-3 mx-auto w-100">
+            {{ $breakdowns := (dict "xs-sm" (dict "size" 1 "class" "d-flex d-md-none") "md" (dict "size" 2 "class" "d-none d-md-flex d-lg-none") "lg" (dict "size" 3 "class" "d-none d-lg-flex d-xl-none") "xl" (dict "size" 4 "class" "d-none d-xl-flex")) }}
             <!-- list adapted from https://getbootstrap.com/docs/4.0/utilities/display/#hiding-elements -->
             {{ range $breakpoint, $carouselInfo := $breakdowns }}
                 {{ $itemsInCarousel := index $carouselInfo "size" }}
                 {{ $breakpointVisibilityClass := index $carouselInfo "class" }}
                 {{ $isMobile := (eq $itemsInCarousel 1) }}
+                {{ $carouselId := (printf "new-course-carousel-%v" $breakpoint) }}
                 <div class="{{ $breakpointVisibilityClass }}">
-                    <div id="carousel-{{ $breakpoint }}" class="carousel slide">
+                    <div id="{{ $carouselId }}" class="carousel slide">
                         <div class="carousel-header d-flex flex-row justify-content-between font-weight-bold text-uppercase">
-                            <h3 class="new-courses-title">New Courses</h3>
-                            <h4 class="d-flex">
-                                <a href="#carousel-{{ $breakpoint }}" role="button" data-slide="prev" class="bg-white prev">
-                                    <span class="material-icons">keyboard_arrow_left</span>
-                                    Previous
-                                </a>
-                                <a href="#carousel-{{ $breakpoint }}" role="button" data-slide="next" class="bg-white next">
-                                    Next
-                                    <span class="material-icons">keyboard_arrow_right</span>
-                                </a>
-                            </h4>
+                            <h3>New Courses</h3>
+                            {{ partial "carousel_controls.html" $carouselId }}
                         </div>
                         <div class="carousel-inner d-flex {{ if not $isMobile }}container{{ end }} mt-2 px-0">
                             {{- range $index, $courseItem := (first 10 $courseItems.results) -}}
@@ -33,7 +24,7 @@
                                     {{ if eq $modulo 0 }}
                                         <div class="carousel-item {{ if not $isMobile }}row{{end}} {{ if eq $group 0 }}active{{ end }}">
                                     {{ end }}
-                                            <div class="course-card-wrapper {{ if not $isMobile }}col-{{ (div 12 $itemsInCarousel) }}{{ end }} w-100 d-flex justify-content-center">
+                                            <div class="item-wrapper {{ if not $isMobile }}col-{{ (div 12 $itemsInCarousel) }}{{ end }} w-100 d-flex justify-content-center">
                                                 <div class="course-card card bg-white">
                                                     <a href="/courses/{{ $courseItem.url_path }}">
                                                       <img src="{{ $courseData.course_image_url }}" alt="Thumbnail for {{ $courseData.course_title }}"/>
@@ -66,5 +57,4 @@
                 </div>
             {{ end }}
         </div>
-    </div>
 {{ end }}

--- a/site/layouts/partials/home_testimonials.html
+++ b/site/layouts/partials/home_testimonials.html
@@ -2,12 +2,9 @@
 {{ $testimonials := where $pages "Type" "==" "testimonials" }}
 <div>
   <div class="testimonials mt-3 mx-auto w-100">
-    <div class="header">
-      <span class="orange font-weight-bold">
-        OpenCourseWare
-      </span>
-      Testimonies
-    </div>
+    <h2 class="branded">
+      <span>OpenCourseWare</span> Testimonies
+    </h2>
     <div class="d-flex flex-row justify-content-between" >
       {{ range $testimonial := $testimonials }}
       <div

--- a/site/layouts/partials/ocw_news.html
+++ b/site/layouts/partials/ocw_news.html
@@ -1,21 +1,59 @@
-<div class="ocw-news mx-auto container">
-    <h3><span class="ocw">OCW</span> News</h3>
-    <div class="d-grid items-row">
-        {{- $newsItems := getJSON (print (strings.TrimSuffix "/" (getenv "OCW_STUDIO_BASE_URL")) "/api/news/") -}}
-        {{ if $newsItems }}
-            {{- range $index, $item := (first 4 $newsItems.items) -}}
-            <div class="item item-{{ $index }}"
-                 style="background: linear-gradient(to bottom, transparent, #777777), url({{ $item.image }})">
-                <a href="{{ $item.link.text }}" class="py-2 px-3 text-white text-decoration-none">
-                    {{ $item.title.text }}
-                </a>
+{{- $newsItems := getJSON (print (strings.TrimSuffix "/" (getenv "OCW_STUDIO_BASE_URL")) "/api/news/") -}}
+{{ if $newsItems.items }}
+    <div class="ocw-news container mx-auto w-100">
+        {{ $breakdowns := (dict "xs-sm" (dict "size" 1 "class" "d-flex d-md-none") "md" (dict "size" 2 "class" "d-none d-md-flex d-lg-none")) }}
+        {{ range $breakpoint, $carouselInfo := $breakdowns }}
+            {{ $itemsInCarousel := index $carouselInfo "size" }}
+            {{ $breakpointVisibilityClass := index $carouselInfo "class" }}
+            {{ $carouselId := (printf "news-carousel-%v" $breakpoint) }}
+            <div class="{{ $breakpointVisibilityClass }}">
+                <div id="{{ $carouselId }}" class="carousel slide">
+                    <div class="carousel-header d-flex flex-row justify-content-between font-weight-bold text-uppercase">
+                        <h2 class="branded"><span>OCW</span> News</h2>
+                        {{ partial "carousel_controls.html" $carouselId }}
+                    </div>
+                    <div class="carousel-inner d-flex mt-2 px-0">
+                        {{- range $index, $newsItem := (first 4 $newsItems.items) -}}
+                            {{ $modulo := (mod $index $itemsInCarousel) }}
+                            {{ $group := (div $index $itemsInCarousel) }}
+                            {{ if eq $modulo 0 }}
+                                <div class="carousel-item row {{ if eq $group 0 }}active{{ end }}">
+                            {{ end }}
+                                <div class="item-wrapper col-{{ (div 12 $itemsInCarousel) }}">
+                                    <div class="item item-{{ $index }}"
+                                         style="background: linear-gradient(to bottom, transparent, #777777), url({{ $newsItem.image }})">
+                                        <a href="{{ $newsItem.link.text }}" class="py-2 px-3 text-white text-decoration-none">
+                                            {{ $newsItem.title.text }}
+                                        </a>
+                                    </div>
+                                </div>
+                            {{ if (or (eq $modulo (sub $itemsInCarousel 1)) (eq $index (sub 4 1))) }}
+                                </div>
+                            {{ end }}
+                        {{ end }}
+                    </div>
+                </div>
             </div>
-            {{ end }}
         {{ end }}
-    </div>
-    <div class="d-flex py-4">
-        <div class="ml-auto">
-            <a class="view-all-news-link" href="https://www.ocw-openmatters.org/">View All News Stories</a>
+
+        <div class="d-none d-lg-block">
+            <h2 class="branded"><span>OCW</span> News</h2>
+            <div class="d-grid items-grid">
+                {{- range $index, $item := (first 4 $newsItems.items) -}}
+                    <div class="item item-{{ $index }}"
+                         style="background: linear-gradient(to bottom, transparent, #777777), url({{ $item.image }})">
+                        <a href="{{ $item.link.text }}" class="py-2 px-3 text-white text-decoration-none">
+                            {{ $item.title.text }}
+                        </a>
+                    </div>
+                {{ end }}
+            </div>
+        </div>
+
+        <div class="d-flex py-4">
+            <div class="ml-auto">
+                <a class="view-all-news-link" href="https://www.ocw-openmatters.org/">View All News Stories</a>
+            </div>
         </div>
     </div>
-</div>
+{{ end }}

--- a/src/css/carousel.scss
+++ b/src/css/carousel.scss
@@ -1,0 +1,78 @@
+.carousel-item.active,
+.carousel-item-next,
+.carousel-item-prev {
+  // this is display: block in bootstrap but we want to have cards laid out properly
+  display: flex;
+}
+
+.carousel {
+  max-width: $max-home-width;
+  width: 100%;
+
+  .carousel-inner {
+    max-width: $max-home-width;
+    width: 100%;
+
+    .carousel-item {
+      margin-left: 0;
+    }
+  }
+
+  .carousel-header {
+    max-width: $max-home-width;
+    margin: 0;
+    align-items: center;
+
+    h2,
+    h3 {
+      margin: 0;
+      padding: 0;
+    }
+
+    a {
+      border: 1px solid $border-dark-color;
+      border-radius: 5px;
+      display: flex;
+      align-items: center;
+      margin-left: 8px;
+      padding: 6px;
+      font-size: 16px;
+      height: 38px;
+
+      @include media-breakpoint-down(xs) {
+        font-size: 12px;
+      }
+
+      span {
+        display: inline;
+      }
+
+      &.prev,
+      &.next {
+        text-decoration: none;
+      }
+
+      @include media-breakpoint-down(xs) {
+        &.next {
+          padding: 6px 2px 6px 10px;
+        }
+
+        &.prev {
+          padding: 6px 10px 6px 2px;
+        }
+      }
+    }
+  }
+
+  .item-wrapper {
+    padding: 0 10px;
+
+    &:first-child {
+      padding-left: 0;
+    }
+
+    &:last-child {
+      padding-right: 0;
+    }
+  }
+}

--- a/src/css/home.scss
+++ b/src/css/home.scss
@@ -221,14 +221,12 @@ $searchbox-height: 50px;
   }
 }
 
-$maxwidth: 1280px;
-
 .social-cards-wrapper {
   background-color: $blue;
 }
 
 .social-cards {
-  max-width: $maxwidth;
+  max-width: $max-home-width;
 
   @include media-breakpoint-down(md) {
     padding: 0;
@@ -291,127 +289,42 @@ $maxwidth: 1280px;
 }
 
 .course-cards {
-  max-width: $maxwidth;
+  max-width: $max-home-width;
 
   a {
     text-decoration: none;
   }
 
-  .course-card-wrapper {
-    padding: 0 10px;
+  .course-card {
+    border: 1px solid $border-gray;
 
-    &:first-child {
-      padding-left: 0;
-    }
+    $radius: 10px;
 
-    &:last-child {
-      padding-right: 0;
-    }
-
-    .course-card {
-      border: 1px solid $border-gray;
-
-      $radius: 10px;
-
-      border-radius: $radius;
-      height: 381px;
-      width: 100%;
-
-      h5 {
-        font-size: 16px;
-      }
-
-      img {
-        width: 100%;
-        object-fit: cover;
-        height: 186px;
-        border-radius: $radius $radius 0 0;
-      }
-
-      .course-level {
-        text-transform: uppercase;
-        color: $font-gray-mid;
-      }
-
-      .course-card-content {
-        font-size: 12px;
-
-        .card-label {
-          color: $give-heart-gray;
-        }
-      }
-    }
-  }
-
-  .carousel-item.active,
-  .carousel-item-next,
-  .carousel-item-prev {
-    // this is display: block in bootstrap but we want to have cards laid out properly
-    display: flex;
-  }
-
-  .carousel {
-    max-width: $maxwidth;
+    border-radius: $radius;
+    height: 381px;
     width: 100%;
 
-    .carousel-inner {
-      max-width: $maxwidth;
-      width: 100%;
-
-      .carousel-item {
-        margin-left: 0;
-
-        @include media-breakpoint-up(md) {
-          padding: 0 10px;
-        }
-      }
+    h5 {
+      font-size: 16px;
     }
 
-    .carousel-header {
-      max-width: $maxwidth;
-      margin: 0;
+    img {
+      width: 100%;
+      object-fit: cover;
+      height: 186px;
+      border-radius: $radius $radius 0 0;
+    }
 
-      @include media-breakpoint-up(md) {
-        padding: 0 10px;
-      }
+    .course-level {
+      text-transform: uppercase;
+      color: $font-gray-mid;
+    }
 
-      @include media-breakpoint-down(xs) {
-        h3 {
-          font-size: 14px;
-        }
+    .course-card-content {
+      font-size: 12px;
 
-        h4 {
-          font-size: 12px;
-        }
-      }
-
-      .new-courses-title {
-        padding: 12px 0 6px 0;
-      }
-
-      a {
-        border: 1px solid $border-dark-color;
-        border-radius: 5px;
-        display: flex;
-        align-items: center;
-        margin-left: 8px;
-        padding: 6px;
-        font-size: 16px;
-        height: 38px;
-
-        span {
-          display: inline;
-        }
-
-        @include media-breakpoint-down(xs) {
-          &.next {
-            padding: 6px 2px 6px 10px;
-          }
-
-          &.prev {
-            padding: 6px 10px 6px 2px;
-          }
-        }
+      .card-label {
+        color: $give-heart-gray;
       }
     }
   }
@@ -422,16 +335,7 @@ $maxwidth: 1280px;
 }
 
 .testimonials {
-  max-width: $maxwidth;
-
-  .header {
-    font-size: 28px;
-    line-height: 34px;
-
-    .orange {
-      color: $orange;
-    }
-  }
+  max-width: $max-home-width;
 
   .testimonial {
     height: 280px;
@@ -487,21 +391,26 @@ $maxwidth: 1280px;
 }
 
 .ocw-news {
-  max-width: $maxwidth;
+  max-width: $max-home-width;
 
-  h3 {
-    font-family: Helvetica, sans-serif;
-    font-weight: 300;
-    font-size: 28px;
-    margin-bottom: 20px;
+  .item {
+    width: 100%;
+    background-size: cover !important;
+    display: flex;
+    align-items: end;
 
-    .ocw {
-      color: $orange;
-      font-weight: 600;
+    a {
+      font-size: 20px;
+      line-height: 24px;
+      font-weight: bold;
     }
   }
 
-  .items-row {
+  .carousel .item {
+    height: 215px;
+  }
+
+  .items-grid {
     height: 375px;
     display: grid;
     grid-template-columns: 1fr 1fr 1fr 1fr;
@@ -514,17 +423,6 @@ $maxwidth: 1280px;
     }
 
     .item {
-      width: 100%;
-      background-size: cover !important;
-      display: flex;
-      align-items: end;
-
-      a {
-        font-size: 20px;
-        line-height: 24px;
-        font-weight: bold;
-      }
-
       &.item-0 {
         grid-row: 1 / 3;
         grid-column: 1 / 3;
@@ -543,14 +441,6 @@ $maxwidth: 1280px;
       &.item-3 {
         grid-row: 2;
         grid-column: 3 / 5;
-      }
-
-      &.item-1,
-      &.item-2,
-      &.item-3 {
-        @include media-breakpoint-down(md) {
-          display: none;
-        }
       }
     }
   }

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -5,6 +5,7 @@
 @import "~offcanvas-bootstrap/src/sass/bootstrap.offcanvas";
 
 @import "breakpoints";
+@import "carousel";
 @import "header";
 @import "home";
 @import "course-nav";
@@ -39,6 +40,40 @@ a {
 
   &:hover {
     color: black;
+  }
+}
+
+h2 {
+  font-size: 28px;
+
+  @include media-breakpoint-down(xs) {
+    font-size: 24px;
+  }
+
+  &.branded {
+    font-family: Helvetica, sans-serif;
+    font-weight: 300;
+
+    span {
+      color: $orange;
+      font-weight: 600;
+    }
+  }
+}
+
+@include media-breakpoint-down(xs) {
+  h2 {
+    font-size: 24px;
+  }
+}
+
+h3 {
+  font-size: 24px;
+}
+
+@include media-breakpoint-down(xs) {
+  h3 {
+    font-size: 18px;
   }
 }
 

--- a/src/css/variables.scss
+++ b/src/css/variables.scss
@@ -36,6 +36,7 @@ $border-darker-gray: #979797;
 $give-heart-gray: #bbbbbb;
 $text-box-border: #a3a3a3;
 $text-box-background: #fbfbfb;
+$max-home-width: 1280px;
 
 $search-bg-gray: #f7f7f7;
 $search-gray: rgba(0, 0, 0, 0.85);


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #15

#### What's this PR do?
- Implements OCW news carousel in mobile/tablet widths (large screen widths still show the news section as a grid)
- Refactors some styles to be more consistent and reusable, and implements the carousel navigation buttons as a partial

#### How should this be manually tested?
Check the home page in mobile, tablet, and large screen widths. The OCW News section should match the [design](https://projects.invisionapp.com/d/main?origin=v7#/console/18552410/437726301/preview?scrollOffset=0). 

#### Any background context you want to provide?
There was no tablet-sized design, so I implemented a 2-item carousel in that view to match the "New Courses" carousel

#### Screenshots (if appropriate)
![ss 2021-01-19 at 17 01 48 ](https://user-images.githubusercontent.com/14932219/105102844-809b3800-5a7d-11eb-8c6f-bc8574b22357.png)
![ss 2021-01-19 at 17 02 08 ](https://user-images.githubusercontent.com/14932219/105102848-8264fb80-5a7d-11eb-912e-a7f69a7b9d64.png)
![ss 2021-01-19 at 17 02 28 ](https://user-images.githubusercontent.com/14932219/105102854-84c75580-5a7d-11eb-9b73-568580c25e55.png)

