### PR TITLE
Don't show suggestion if it is effectively the same as search text

### DIFF
--- a/src/js/components/SearchPage.js
+++ b/src/js/components/SearchPage.js
@@ -52,7 +52,16 @@ export default function SearchPage() {
       const { suggest } = newResults
       if (!emptyOrNil(suggest) && !emptyOrNil(text)) {
         setSuggestions(
-          without([text], suggest).map(suggestion =>
+          without(
+            [
+              text
+                .toLowerCase()
+                .replace(/^"(.*)"$/, "$1")
+                .replace(/[\W]+/g, " ")
+                .trim()
+            ],
+            suggest
+          ).map(suggestion =>
             isDoubleQuoted(text) ? `"${suggestion}"` : suggestion
           )
         )

--- a/src/js/components/SearchPage.js
+++ b/src/js/components/SearchPage.js
@@ -56,6 +56,7 @@ export default function SearchPage() {
             [
               text
                 .toLowerCase()
+                .trim()
                 .replace(/^"(.*)"$/, "$1")
                 .replace(/[\W]+/g, " ")
                 .trim()

--- a/src/js/components/SearchPage.js
+++ b/src/js/components/SearchPage.js
@@ -65,6 +65,8 @@ export default function SearchPage() {
             isDoubleQuoted(text) ? `"${suggestion}"` : suggestion
           )
         )
+      } else {
+        setSuggestions(null)
       }
 
       setSearchFacets(new Map(Object.entries(newResults.aggregations ?? {})))

--- a/src/js/components/SearchPage.test.js
+++ b/src/js/components/SearchPage.test.js
@@ -194,7 +194,7 @@ describe("SearchPage component", () => {
 
   test("should not show suggestion if it is the same as query minus quotes, case", async () => {
     const parameters = {
-      text: '"Mathematics: Basic Principles!"'
+      text: ' "Mathematics: Basic Principles!" '
     }
     const searchString = serializeSearchParams(parameters)
     const wrapper = await render(searchString)

--- a/src/js/components/SearchPage.test.js
+++ b/src/js/components/SearchPage.test.js
@@ -189,6 +189,7 @@ describe("SearchPage component", () => {
     wrapper.find(".suggestion").simulate("click")
     wrapper.update()
     expect(wrapper.find("SearchBox").prop("value")).toEqual("mathematics")
+    expect(!wrapper.find(".suggestion").exists())
   })
 
   test("should not show suggestion if it is the same as query minus quotes, case", async () => {

--- a/src/js/components/SearchPage.test.js
+++ b/src/js/components/SearchPage.test.js
@@ -191,6 +191,19 @@ describe("SearchPage component", () => {
     expect(wrapper.find("SearchBox").prop("value")).toEqual("mathematics")
   })
 
+  test("should not show suggestion if it is the same as query minus quotes, case", async () => {
+    const parameters = {
+      text: '"Mathematics: Basic Principles!"'
+    }
+    const searchString = serializeSearchParams(parameters)
+    const wrapper = await render(searchString)
+    await resolveSearch({
+      suggest: ["mathematics basic principles"]
+    })
+    wrapper.update()
+    expect(!wrapper.find(".suggestions").exists())
+  })
+
   it("should show spinner when searching", async () => {
     const wrapper = await render()
     await resolveSearch()


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #34 

#### What's this PR do?
Makes the search text lowercase and strips it of non alphanumeric chars and trailing spaces before comparing it to the recommended search suggestion to determine if the suggestion should be displayed or not.

#### How should this be manually tested?
Perform a search included a search term in quotes with a colon in between words, that only returns 1 result, like "Fiction: Great Books!" On https://ocwnext.odl.mit.edu/search/?q=%22Fiction%3A%20Great%20Books%21%22 the suggested search term "fiction great books" will display.  On this branch, the suggested search term should not display.  Change the search term to "Fiction: Great Boos!" and it should display.

Search for "physacs", you should see a suggested term of "physics".  Then search for "chemistry".  The suggested search term will disappear.  On CI/RC, the old suggestion will remain visible.

