### PR TITLE
fix regression on promo carousel

### DIFF
--- a/src/css/carousel.scss
+++ b/src/css/carousel.scss
@@ -1,13 +1,13 @@
-.carousel-item.active,
-.carousel-item-next,
-.carousel-item-prev {
-  // this is display: block in bootstrap but we want to have cards laid out properly
-  display: flex;
-}
-
-.carousel {
+.carousel:not(.slide) {
   max-width: $max-home-width;
   width: 100%;
+
+  .carousel-item.active,
+  .carousel-item-next,
+  .carousel-item-prev {
+    // this is display: block in bootstrap but we want to have cards laid out properly
+    display: flex;
+  }
 
   .carousel-inner {
     max-width: $max-home-width;


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?

fixes #37

#### What's this PR do?

this fixes a style regression for the promo carousel introduced by #32 - basically, some styling was applied to all `.carousel` elements that we don't want to apply to the promo carousel.

#### How should this be manually tested?

check our prod or the `main` branch and confirm the issue. then confirm this fixes it.

![Screenshot from 2021-01-22 08-32-12](https://user-images.githubusercontent.com/6207644/105497139-77cc8100-5c8c-11eb-82e3-5ce191c4b262.png)
