### PR TITLE
Google Tag Manager JS and .env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 SEARCH_API_URL=http://localhost:8063/api/v0/search/
 OCW_STUDIO_BASE_URL=http://localhost:8043
+GTM_ACCOUNT_ID=

--- a/site/layouts/_default/baseof.html
+++ b/site/layouts/_default/baseof.html
@@ -1,7 +1,14 @@
+{{- $gtmId := getenv "GTM_ACCOUNT_ID" -}}
 <!doctype html>
 <html lang="{{ $.Site.Language.Lang }}">
   {{ partial "head.html" . }}
   <body>
+    {{ if $gtmId }}
+      <!-- Google Tag Manager (noscript) -->
+      <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ $gtmId }}"
+      height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+      <!-- End Google Tag Manager (noscript) -->
+    {{ end }}
     <div class="overflow-auto">
       {{ block "main" . }}{{ end }}
     </div>

--- a/site/layouts/partials/head.html
+++ b/site/layouts/partials/head.html
@@ -1,4 +1,14 @@
+{{- $gtmId := getenv "GTM_ACCOUNT_ID" -}}
 <head>
+  {{ if $gtmId }}
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','{{ $gtmId }}');</script>
+    <!-- End Google Tag Manager -->
+  {{ end }}
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   {{ partial "title.html" . }}


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #19 

#### What's this PR do?
- Adds JS code for Google Tag Manager, which can then be set up with Google Analytics tags

#### How should this be manually tested?
- Create a test Google Analytics account for something like `ocw.odl.local`
- Create a test Google Tag Manager account and add an Analytics tag
- [This link](https://www.analyticsmania.com/post/how-to-install-google-analytics-4-with-google-tag-manager/) might be useful in stepping through the above.
- If you run `npm start` without setting `GTM_ACCOUNT_ID` in your `.env` file, there should not be any google scripts on the page.
- If you set `GTM_ACCOUNT_ID=<your_gtm_id>` in the `.env` file and run `npm start`, there should be GTM JS code in the header and an iframe at the beginning of the body.  Both should contain your account id.
- Load the page (and maybe some search pages) a few times, then check your analytics account, you should see some hits.


#### Where should the reviewer start?
https://developers.google.com/tag-manager/quickstart

