### PR TITLE
Fixed course site variable reference (url_path)

### DIFF
--- a/site/layouts/partials/home_course_cards.html
+++ b/site/layouts/partials/home_course_cards.html
@@ -26,7 +26,7 @@
                                 {{ end }}
                                         <div class="item-wrapper {{ if not $isMobile }}col-{{ (div 12 $itemsInCarousel) }}{{ end }} w-100 d-flex justify-content-center">
                                             <div class="course-card card bg-white">
-                                                <a href="/courses/{{ $courseItem.url_path }}">
+                                                <a href="/courses/{{ $courseData.course_id }}">
                                                   <img src="{{ $courseData.course_image_url }}" alt="Thumbnail for {{ $courseData.course_title }}"/>
                                                 </a>
                                                 <div class="course-card-content pt-1 px-3 pb-3">
@@ -35,7 +35,7 @@
                                                     </div>
                                                     <div class="pt-1">
                                                         <h5>
-                                                            <a href="/courses/{{ $courseItem.url_path }}">{{ $courseData.course_title }}</a>
+                                                            <a href="/courses/{{ $courseData.course_id }}">{{ $courseData.course_title }}</a>
                                                         </h5>
                                                     </div>
                                                     <div class="pt-1">


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
N/A - fixes bug introduced by https://github.com/mitodl/ocw-studio/pull/50

#### What's this PR do?
Fixes a reference to a deprecated field in the Websites API results

#### How should this be manually tested?
Run the site with an updated ocw-studio running locally. The New Courses section links should have the correct destinations
