### PR TITLE
New facet for course feature tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@babel/preset-env": "^7.10.4",
     "@babel/preset-react": "^7.7.0",
     "@babel/register": "^7.10.5",
-    "@mitodl/course-search-utils": "^1.1.1",
+    "@mitodl/course-search-utils": "^1.1.2",
     "@sentry/browser": "^5.19.0",
     "archiver": "^5.0.0",
     "assets-webpack-plugin": "^3.9.7",

--- a/src/js/components/SearchPage.js
+++ b/src/js/components/SearchPage.js
@@ -23,7 +23,7 @@ const COURSE_FACETS = [
   ["level", "Level", false],
   ["topics", "Topics", true],
   ["department_name", "Department", true],
-  ["course_feature_tags", "Feature Tags", true],
+  ["course_feature_tags", "Feature Tags", true]
 ]
 
 // TBD

--- a/src/js/components/SearchPage.js
+++ b/src/js/components/SearchPage.js
@@ -22,8 +22,8 @@ export const SEARCH_PAGE_SIZE = 10
 const COURSE_FACETS = [
   ["level", "Level", false],
   ["topics", "Topics", true],
-  ["department_name", "Department", true],
-  ["course_feature_tags", "Feature Tags", true]
+  ["course_feature_tags", "Course Features", true],
+  ["department_name", "Department", true]
 ]
 
 // TBD

--- a/src/js/components/SearchPage.js
+++ b/src/js/components/SearchPage.js
@@ -22,7 +22,8 @@ export const SEARCH_PAGE_SIZE = 10
 const COURSE_FACETS = [
   ["level", "Level", false],
   ["topics", "Topics", true],
-  ["department_name", "Department", true]
+  ["department_name", "Department", true],
+  ["course_feature_tags", "Feature Tags", true],
 ]
 
 // TBD

--- a/src/js/components/SearchPage.test.js
+++ b/src/js/components/SearchPage.test.js
@@ -273,14 +273,17 @@ describe("SearchPage component", () => {
     expect(wrapper.find("Loading").exists()).toBeFalsy()
   })
 
-  test("should render a FilterableFacet for topic, department", async () => {
+  test("should render a FilterableFacet for topic, course features, department", async () => {
     const wrapper = await render()
     await resolveSearch()
     wrapper.update()
-    const [topic, department] = wrapper.find(FilterableFacet)
+    const [topic, features, department] = wrapper.find(FilterableFacet)
     expect(topic.props.name).toEqual("topics")
     expect(topic.props.title).toEqual("Topics")
     expect(topic.props.currentlySelected).toEqual([])
+    expect(features.props.name).toEqual("course_feature_tags")
+    expect(features.props.title).toEqual("Course Features")
+    expect(features.props.currentlySelected).toEqual([])
     expect(department.props.name).toEqual("department_name")
     expect(department.props.title).toEqual("Department")
     expect(department.props.currentlySelected).toEqual([])

--- a/src/js/components/SearchPage.test.js
+++ b/src/js/components/SearchPage.test.js
@@ -140,7 +140,10 @@ describe("SearchPage component", () => {
   test("the user can switch to resource search", async () => {
     const parameters = {
       text:         "Math 101",
-      activeFacets: { topics: ["mathematics"] }
+      activeFacets: {
+        topics:              ["mathematics"],
+        course_feature_tags: ["Exams", "Problem Sets with Solutions"]
+      }
     }
     const searchString = serializeSearchParams(parameters)
     const wrapper = await render(searchString)

--- a/src/js/factories/search.js
+++ b/src/js/factories/search.js
@@ -96,7 +96,8 @@ export const makeCourseResult = () => ({
     [PROFESSIONAL],
     [OPEN_CONTENT, PROFESSIONAL]
   ]),
-  certification: casual.random_element([[], [CERTIFICATE]])
+  certification:       casual.random_element([[], [CERTIFICATE]]),
+  course_feature_tags: [casual.word, casual.word]
 })
 
 export const makeResourceFileResult = () => ({

--- a/src/js/lib/search.js
+++ b/src/js/lib/search.js
@@ -84,7 +84,8 @@ const COURSE_QUERY_FIELDS = [
   "course_id",
   "coursenum^5",
   "offered_by",
-  "department_name"
+  "department_name",
+  "course_feature_tags"
 ]
 const VIDEO_QUERY_FIELDS = [
   "title.english^3",
@@ -457,7 +458,8 @@ export const searchResultToLearningResource = result => ({
   short_url:     result.short_url || null,
   course_id:     result.course_id || null,
   coursenum:     result.coursenum || null,
-  description:   result.short_description || null
+  description:   result.short_description || null,
+  course_feature_tags:  result.course_feature_tags ? result.course_feature_tags : []
 })
 
 export const getCoverImageUrl = result => {

--- a/src/js/lib/search.js
+++ b/src/js/lib/search.js
@@ -438,28 +438,30 @@ export const SEARCH_GRID_UI = "grid"
 export const SEARCH_LIST_UI = "list"
 
 export const searchResultToLearningResource = result => ({
-  id:            result.id,
-  title:         result.title,
-  image_src:     result.image_src,
-  object_type:   result.object_type,
-  platform:      "platform" in result ? result.platform : null,
-  topics:        result.topics ? result.topics.map(topic => ({ name: topic })) : [],
-  runs:          "runs" in result ? result.runs : [],
-  level:         !emptyOrNil(result.runs) ? result.runs[0].level : null,
-  instructors:   !emptyOrNil(result.runs) ? result.runs[0].instructors : [],
-  department:    result.department,
-  audience:      result.audience,
-  certification: result.certification,
-  content_title: result.content_title,
-  run_title:     result.run_title || null,
-  run_slug:      result.run_slug || null,
-  content_type:  result.content_type || null,
-  url:           getResultUrl(result) || null,
-  short_url:     result.short_url || null,
-  course_id:     result.course_id || null,
-  coursenum:     result.coursenum || null,
-  description:   result.short_description || null,
-  course_feature_tags:  result.course_feature_tags ? result.course_feature_tags : []
+  id:                  result.id,
+  title:               result.title,
+  image_src:           result.image_src,
+  object_type:         result.object_type,
+  platform:            "platform" in result ? result.platform : null,
+  topics:              result.topics ? result.topics.map(topic => ({ name: topic })) : [],
+  runs:                "runs" in result ? result.runs : [],
+  level:               !emptyOrNil(result.runs) ? result.runs[0].level : null,
+  instructors:         !emptyOrNil(result.runs) ? result.runs[0].instructors : [],
+  department:          result.department,
+  audience:            result.audience,
+  certification:       result.certification,
+  content_title:       result.content_title,
+  run_title:           result.run_title || null,
+  run_slug:            result.run_slug || null,
+  content_type:        result.content_type || null,
+  url:                 getResultUrl(result) || null,
+  short_url:           result.short_url || null,
+  course_id:           result.course_id || null,
+  coursenum:           result.coursenum || null,
+  description:         result.short_description || null,
+  course_feature_tags: result.course_feature_tags ?
+    result.course_feature_tags :
+    []
 })
 
 export const getCoverImageUrl = result => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1319,10 +1319,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@mitodl/course-search-utils@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@mitodl/course-search-utils/-/course-search-utils-1.1.1.tgz#e3d8e59102a27a31edbbb32e78055d9f051a8e8f"
-  integrity sha512-XdpMMuFrZSHunceg6C9b8QjwD/tQOJ0TDKQsTZRzfU8j3ODZT6sPsWBDejMlzXeY/apgs37M+s4Aj460d6JsUQ==
+"@mitodl/course-search-utils@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@mitodl/course-search-utils/-/course-search-utils-1.1.2.tgz#14fdc1b01dde1572903df925622f5cf52a0c7ac6"
+  integrity sha512-KWBODgXnZUauv9luYzBBr/M35A8x3m+umoQbD9EWKAyM9ZQdOdL+RbRJYVedNV7e/RgxjS1S/TPucLlbCnFkqg==
   dependencies:
     query-string "^6.13.1"
     ramda "^0.27.1"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #59 

#### What's this PR do?
Adds a search facet for course feature tags

#### How should this be manually tested?
You will need open-discussions running, with some imported OCW courses.  If you imported them awhile ago, you might need to reimport them again to make sure the `Course.course_feature_tags` field is populated.

Go to the search page for courses.  There should be a populated facet for "Course Features" with counts, above the Departments facet.  Selecting certain tags should update the search results and url parameters.  Courses in search results should include the selected tags (you'll need to look at the hits returned by Elasticsearch to verify this).

#### Screenshots (if appropriate)
<img width="297" alt="Screen Shot 2021-03-16 at 2 14 54 PM" src="https://user-images.githubusercontent.com/187676/111359802-58d1e600-8662-11eb-824e-9f876f890336.png">
