### PR TITLE
Mail signup will redirect to legacy signup form

### DIFF
--- a/site/layouts/partials/newsletter_signup.html
+++ b/site/layouts/partials/newsletter_signup.html
@@ -1,13 +1,7 @@
-{{- $userId := getenv "MAILCHIMP_USER_ID" -}}
-{{- $audienceId := getenv "MAILCHIMP_AUDIENCE_ID" -}}
-<form action="https://mit.us2.list-manage.com/subscribe/post-json?u={{ $userId }}&amp;id={{ $audienceId }}&amp;c=?" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="newsletter-form d-flex" target="_blank" novalidate>
+<form action="https://ocw.mit.edu/subscribe/index.htm?utm_source=ocwnext" method="get" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="newsletter-form d-flex" target="_blank" novalidate>
     <div class="icon-text-box-wrapper d-flex flex-row flex-grow-1 form-group bg-white shadow-sm border-dark-gray p-0 m-0">
         <img class="input-group-prepend px-2" src="/images/envelope.svg" />
         <input type="email" value="" name="EMAIL" class="email form-control border-0" id="mce-EMAIL" placeholder="Your email address...">
-    </div>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true">
-        <input type="text" name="b_{{ $userId }}_{{ $audienceId }}" tabindex="-1" value="">
     </div>
     <div class="btn rounded-0 px-3 py-2 h-100 my-3 my-xl-0 ml-xl-3 signup-link">
         <a href="#" class="text-white text-decoration-none">SIGN ME UP</a>

--- a/src/js/mailchimp.js
+++ b/src/js/mailchimp.js
@@ -1,28 +1,8 @@
 const setupEmailSignupForm = () => {
   const $form = $(".newsletter-form")
-  const $message = $(".newsletter-signup-result")
   $form.find(".signup-link").click(event => {
     event.preventDefault()
     $form.submit()
-  })
-
-  $form.submit(async event => {
-    event.preventDefault()
-    const url = $form.attr("action")
-    for (const item of $form.serializeArray()) {
-      if (item.name === "EMAIL" && !item.value) {
-        // ignore for empty emails
-        return
-      }
-    }
-
-    const response = await $.ajax({
-      url:      url,
-      data:     $form.serialize(),
-      dataType: "json",
-      method:   $form.attr("method")
-    })
-    $message.html(response.msg)
   })
 }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #62 

#### What's this PR do?
On form submission, user will be redirected to the legacy OCW signup form.

#### How should this be manually tested?
Scroll to the bottom and click "Sign me up". You should have a new tab opened to the legacy form. Pressing enter while the user has focus on the textbox will also do the same thing. Note that the text in the textbox will be ignored -- the user will need to type the email in the legacy form for it to take effect.