### PR TITLE
add generic page layout

### DIFF
--- a/site/archetypes/pages.md
+++ b/site/archetypes/pages.md
@@ -1,0 +1,5 @@
+{{- $name := replaceRE "-" " " .Name | replaceRE "_" " " | title -}}
+---
+title: "{{ $name }}"
+date: {{ .Date }}
+---

--- a/site/archetypes/pages.md
+++ b/site/archetypes/pages.md
@@ -3,3 +3,5 @@
 title: "{{ $name }}"
 date: {{ .Date }}
 ---
+
+**Insert content here**

--- a/site/content/pages/_index.md
+++ b/site/content/pages/_index.md
@@ -1,0 +1,4 @@
+---
+title: Pages
+type: pages
+---

--- a/site/layouts/pages/single.html
+++ b/site/layouts/pages/single.html
@@ -1,0 +1,11 @@
+{{ define "main" }}
+<div class="overflow-auto">
+  {{ block "header" . }}
+  {{ partialCached "header" . }}
+  {{ partialCached "header_placeholder.html" . }}
+  {{end}}
+  <div class="generic-single container standard-width mx-auto mt-5">
+  {{ .Content }}
+  </div>
+</div>
+{{ end }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review

#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-www/issues/69

#### What's this PR do?
We are going to be adding a notification system to `ocw-www`.  This PR adds a layout and archetype that allows for the creation of generic "pages" to be used for one-off purposes like linking from these notifications.

#### How should this be manually tested?
 - In the `site` directory, run `hugo new pages/test.md`
 - Start the site and browse to http://localhost:3000/pages/test/, you should see a blank page with the text "Insert content here"
 - Make an edit to `site/content/pages/test.md` and save the file, ensure the content is updated at the link above

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/112694070-183f4d00-8e58-11eb-81ce-35763b7afc6c.png)
![image](https://user-images.githubusercontent.com/12089658/112694120-2f7e3a80-8e58-11eb-8668-1e1f6558ba61.png)

