### PR TITLE
fix header background width

### DIFF
--- a/site/layouts/partials/page_title.html
+++ b/site/layouts/partials/page_title.html
@@ -1,4 +1,4 @@
-<div class="page-title mx-auto">
+<div class="page-title">
   <div class="title-text m-auto h1 m-0">
   {{ .Title }}
   </div>

--- a/src/css/header.scss
+++ b/src/css/header.scss
@@ -58,11 +58,11 @@
       display: flex;
       flex-direction: row;
       justify-content: center;
+      background-color: black;
 
       .contents {
         width: 100%;
         max-width: $desktop-header-max-width;
-        background-color: black;
 
         .right {
           a {

--- a/src/css/pages.scss
+++ b/src/css/pages.scss
@@ -2,12 +2,12 @@
   .page-title {
     color: $white;
     background-color: $blue;
-    max-width: $desktop-header-max-width;
 
     @include media-breakpoint-up(lg) {
       padding: 3.5rem 5rem;
 
       .title-text {
+        max-width: $max-content-width;
         font-size: 3rem;
       }
     }


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-www/issues/80

#### What's this PR do?
This PR ensures that the black background color used on the header on pages other than the home page is on the correct element so it spans the width of the page.  The same applies to the header used on the generic page template.

#### How should this be manually tested?
Run the site and ensure the headers remain centered but the background spans the width of the page.  Check:

 - http://localhost:3000/search
 - http://localhost:3000/pages/beta

#### Screenshots (if appropriate)
![chrome_2021-03-31_10-04-06](https://user-images.githubusercontent.com/12089658/113158121-80e84a00-9209-11eb-8673-9d21dae672f0.png)
![chrome_2021-03-31_10-04-45](https://user-images.githubusercontent.com/12089658/113158126-82b20d80-9209-11eb-9284-6a06fb678662.png)
![chrome_2021-03-31_10-10-16](https://user-images.githubusercontent.com/12089658/113158133-83e33a80-9209-11eb-9d6b-cbb1e13e2cb0.png)
![chrome_2021-03-31_10-10-37](https://user-images.githubusercontent.com/12089658/113158140-85acfe00-9209-11eb-9426-74f299efe579.png)

