### PR TITLE
consistent header style

### DIFF
--- a/site/layouts/home.html
+++ b/site/layouts/home.html
@@ -1,5 +1,7 @@
 {{ define "main" }}
+<div id="home-header">
 {{ block "header" . }}{{ partial "header" . }}{{ end }}
+</div>
 <div class="d-flex flex-column align-items-center home-banner" style="background-image: url(/images/homepage_hero.jpg);">
   <div class="banner-contents-container mx-auto d-flex justify-content-start justify-content-md-around w-100 align-items-center h-100">
     <div class="first-column m-md-2 d-flex flex-column">

--- a/src/css/header.scss
+++ b/src/css/header.scss
@@ -12,7 +12,10 @@
 #desktop-header {
   height: $desktop-header-height;
   width: 100%;
-  position: absolute;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  background-color: black;
 
   @include media-breakpoint-down(md) {
     display: none;
@@ -23,6 +26,7 @@
     justify-content: space-between;
     max-width: $max-content-width;
     margin: auto;
+    width: 100%;
     height: 100%;
 
     .right,
@@ -46,33 +50,19 @@
       a {
         font-size: 14px;
         text-transform: uppercase;
+
+        &.orange-link {
+          font-size: 1rem;
+        }
       }
     }
   }
 }
 
-.search-wrapper,
-.page-single {
+#home-header {
   #desktop-header {
-    @include media-breakpoint-up(lg) {
-      display: flex;
-      flex-direction: row;
-      justify-content: center;
-      background-color: black;
-
-      .contents {
-        width: 100%;
-        max-width: $desktop-header-max-width;
-
-        .right {
-          a {
-            &.orange-link {
-              font-size: 1rem;
-            }
-          }
-        }
-      }
-    }
+    position: absolute;
+    background-color: transparent;
   }
 }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review

#### What are the relevant tickets?
Fixes https://github.com/mitodl/ocw-www/issues/87

#### What's this PR do?
The home page is the only page currently with different styling for the header than other pages.  The only difference is that the background needs to be transparent and it needs to be absolutely positioned to sit on top of the homepage hero image.  This PR makes the style consistent across the site and only applies absolute positioning and a transparent background to the homepage header.

#### How should this be manually tested?
 - Spin up the site
 - Visit the home page and ensure the header displays properly with a transparent background over the hero image
 - Visit the other pages and ensure the header is consistent:
  - Search
  - Beta notification page
  - Testimonial
  - Promo

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/113743788-0f5d3f80-96d2-11eb-9191-e9226e45316b.png)
![image](https://user-images.githubusercontent.com/12089658/113743861-20a64c00-96d2-11eb-82d5-c4c6faaefde8.png)
![image](https://user-images.githubusercontent.com/12089658/113743918-30259500-96d2-11eb-8b15-01e8e29cd542.png)
![image](https://user-images.githubusercontent.com/12089658/113743978-40d60b00-96d2-11eb-81d9-1e13f0fa029d.png)

