### PR TITLE
remove header_placeholder

### DIFF
--- a/site/layouts/pages/single.html
+++ b/site/layouts/pages/single.html
@@ -2,7 +2,6 @@
 <div class="page-single">
   {{ block "header" . }}
   {{ partialCached "header" . }}
-  {{ partialCached "header_placeholder" . }}
   {{ partialCached "page_title" . }}
   {{end}}
   <div class="container standard-width mx-auto mt-5">    

--- a/site/layouts/partials/header_placeholder.html
+++ b/site/layouts/partials/header_placeholder.html
@@ -1,2 +1,0 @@
-<div class="header-placeholder">
-</div>

--- a/site/layouts/search/section.html
+++ b/site/layouts/search/section.html
@@ -2,7 +2,6 @@
 <div class="search-wrapper">
   {{ block "header" . }}
   {{ partialCached "header" . }}
-  {{ partialCached "header_placeholder.html" . }}
   {{end}}
   <div class="container-fluid">
     <main aria-role="main">

--- a/site/layouts/testimonials/list.html
+++ b/site/layouts/testimonials/list.html
@@ -4,7 +4,6 @@
 <div>
   {{ block "header" . }}
   {{ partialCached "header" . }}
-  {{ partialCached "header_placeholder.html" . }}
   {{end}}
   <div class="testimonial-section container standard-width mx-auto mt-5">
     <h1>OCW Testimonies</h1>

--- a/site/layouts/testimonials/single.html
+++ b/site/layouts/testimonials/single.html
@@ -3,7 +3,6 @@
 <div>
   {{ block "header" . }}
   {{ partialCached "header" . }}
-  {{ partialCached "header_placeholder.html" . }}
   {{end}}
   <div class="testimonial-single container standard-width mx-auto mt-5">
     <h1>OCW Testimonies</h1>

--- a/src/css/header.scss
+++ b/src/css/header.scss
@@ -65,11 +65,3 @@
     background-color: transparent;
   }
 }
-
-.header-placeholder {
-  height: $desktop-header-height;
-
-  @include media-breakpoint-down(md) {
-    display: none;
-  }
-}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review

#### What are the relevant tickets?
Fixes https://github.com/mitodl/ocw-www/issues/91

#### What's this PR do?
Recently, a PR was merged that only applies absolute positioning to the header on the home page where it is needed.  An unnoticed side effect of this is that previously the `header_placeholder.html` was being used to push down the content on other pages so it sat under the header.  This is now unnecessary, because pages other than the home page now use flexbox positioning.  This PR removes the `header_placeholder.html` partial.

#### How should this be manually tested?
 - Spin up the site
 - Visit the following pages and ensure that there is no whitespace in between the header and the page content:
  - http://localhost:3000/
  - http://localhost:3000/search/?q=
  - http://localhost:3000/testimonials/tuhin-bagi/
  - http://localhost:3000/pages/beta/

#### Screenshots (if appropriate)
![chrome_2021-04-09_12-07-11](https://user-images.githubusercontent.com/12089658/114209084-3b73fd00-992c-11eb-9493-80d279426d6d.png)
![chrome_2021-04-09_12-07-28](https://user-images.githubusercontent.com/12089658/114209087-3ca52a00-992c-11eb-8128-5e3781a326fb.png)

