### PR TITLE
remove dev baseurl from the config

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -1,3 +1,4 @@
+baseUrl = "/"
 languageCode = "en-us"
 title = "MIT OpenCourseWare"
 relativeURLs = false

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -1,4 +1,3 @@
-baseURL = "http://localhost:3000/"
 languageCode = "en-us"
 title = "MIT OpenCourseWare"
 relativeURLs = false


### PR DESCRIPTION
#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-www/issues/111

#### What's this PR do?
In moving to using `ocw-hugo-themes`, a recent RC build revealed that all pages built using `ocw-www`'s content have a `baseUrl` of `http://localhost:3000`.  This PR removes an errant `baseUrl = "http://localhost:3000/"` setting from the default `config.toml` file, not assuming a default `baseUrl`.

#### How should this be manually tested?
This is part of https://github.com/mitodl/ocw-hugo-themes/pull/18 and the testing instructions in that PR apply to this one as well.

