### PR TITLE
remove the search placeholder

### DIFF
--- a/content/search/_index.md
+++ b/content/search/_index.md
@@ -1,4 +1,0 @@
----
-title: Search
-type: search
----


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/95
Part of https://github.com/mitodl/ocw-hugo-themes/pull/96

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-themes/pull/96, we added the `content/search/_index.md` placeholder for rendering the search app directly to the theme so it's rendered by default and is not dependent on the file existing within the Hugo project utilizing the theme.  This PR removes this placeholder from `ocw-www`

#### How should this be manually tested?
The testing instructions in https://github.com/mitodl/ocw-hugo-themes/pull/96 apply to this PR as well.

#### Additional info
https://github.com/mitodl/ocw-hugo-themes/pull/96 should be merged and released before this PR so that the search page does not disappear 
