### PR TITLE
add an explicit production config that explicitly does not ignore errors

### DIFF
--- a/config/production/config.toml
+++ b/config/production/config.toml
@@ -1,0 +1,2 @@
+# Make sure errors stop the build
+ignoreErrors = []


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
n/a

#### What's this PR do?
This PR adds an explicit production configuration for `ocw-www` to ensure that no errors are ignored and the build is stopped if any are encountered.  On 7/19/2021, a production build of the OCW next site failed to fetch new courses and news items from `ocw-studio` production (thread here: https://mitodl.slack.com/archives/C020SSRLPHS/p1626705116063900) and the build continued anyway when it should have been stopped.  According to the Hugo documentation (https://gohugo.io/getting-started/configuration/#configuration-directory) by default `hugo server` is supposed to use the `development` configuration and `hugo` uses the `production` configuration.  In theory, this should mean that `development` is only used if you're running `hugo server`, but either way explicitly defining the production configuration should be a good failsafe.

#### How should this be manually tested?
1.  Clone `ocw-hugo-themes` and set `EXTERNAL_SITE_PATH` to the path to `ocw-www` (on the `cg/production-config` branch) and set `OCW_STUDIO_BASE_URL` to `http://localhost:8043`, but don't start `ocw-studio`
2. Run `npm start` (the build should succeed)
3. Visit http://localhost:3000/ where you should see the OCW home page with some error messages about new courses and news items
4. Back in `ocw-hugo-themes`, run `npm run build`
5. Verify that the build does not succeed and throws a `getJSON` error

