### PR TITLE
add JSON media types and outputs

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -29,3 +29,9 @@ enableRobotsTXT = true
 [caches.getjson]
 # set getJSON cache age small enough to refresh on every build but large enough to cache usefully within a build
 maxAge = "5m"
+
+[mediaTypes."application/json"]
+suffixes = [ "json" ]
+
+[outputs]
+page = [ "HTML", "JSON" ]


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-www/issues/129

#### What's this PR do?
This PR adds the proper `mediaType` and `output` values to the Hugo configuration to make sure that JSON is exported where a layout is defined to do so.

#### How should this be manually tested?
 - Clone `ocw-hugo-themes`
 - Spin up the webpack dev server in `ocw-hugo-themes` locally by running `npm run start:site:webpack`
 - Clone this repo on the `cg/json-media-types` branch
 - Run `hugo server --themesDir /path/to/ocw-hugo-themes/`, replacing the path to `ocw-hugo-themes` with your own
 - Pick an instructor in the source `ocw-www` data and visit your local dev site verifying that the instructor exists and data is returned, for example: http://localhost:1313/instructors/0a90e4c5-5f99-646e-cbfc-402250d8aba5/index.json
