### PR TITLE
remove bad notification

### DIFF
--- a/content/notifications/beta.md
+++ b/content/notifications/beta.md
@@ -1,7 +1,0 @@
----
-uid: "1617053517682872100"
-title: "Beta Notification"
-date: 2021-03-29T17:31:57-04:00
-headless: true
----
-##### **Welcome to NextGen OCW! Help us improve this beta site. [Learn more](/pages/beta).**


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-www/issues/133

#### What's this PR do?
In https://github.com/mitodl/ocw-www/pull/122/files, the `content/notifications/beta.md` file was removed and replaced with `beta-notification.md` that has a link pointing to `pages/welcome-to-the-nextgen-ocw-beta-site`, to replicate how `ocw-studio` would generate the page.  At some point the `beta.md` file was restored which caused it to become the newest notification, displaying instead of `welcome-to-the-nextgen-ocw-beta-site.md`.  This PR removes it again so the correct link is rendered.

#### How should this be manually tested?
 - Clone `ocw-hugo-themes` and make sure `EXTERNAL_SITE_PATH` is pointing to this repo cloned locally on this PR's branch, `cg/remove-bad-notification`
 - In your `ocw-hugo-themes` folder, run `yarn install` if you've never spun up a site before, then run `npm start` to spin up the OCW home page
 - In an incognito window, go to http://localhost:3000 and click the link in the banner at the top
 - Verify that the beta notification page is displayed
